### PR TITLE
Fix use array access for multiple files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-rework",
   "description": "work on your css files with rework",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/jney/grunt-rework",
   "author": {
     "name": "Jean-Sébastien Ney",

--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
         var css = rework(srcCode).vendors(options.vendors);
 
         options.use.forEach(function (e) {
+          e = e.slice();
           var fnName = e.shift();
           var fnArgs = e.map(function (arg) {
             return JSON.stringify(arg);


### PR DESCRIPTION
This allows us to use the file.expand method of specifying src-dest file mappings in grunt.
Previously, the `e.shift()` made it so repeated use of the `use` failed.
The added `e.slice()` protects its modification.
