### PR TITLE
Support 3rd-party Rework plugins

### DIFF
--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -36,15 +36,16 @@ module.exports = function(grunt) {
         options.use.forEach(function (e) {
           e = e.slice();
           var fnName = e.shift();
+          
+          if (typeof fnName === 'function') {
+            return css.use(fnName(e));
+          }
+          
           var fnArgs = e.map(function (arg) {
             return JSON.stringify(arg);
           }).join(', ');
-          if (typeof fnName === 'function') {
-            css.use(fnName(fnArgs));
-          }
-          else {
-            css.use(eval(fnName + '(' + fnArgs + ')'));
-          }
+          
+          css.use(eval(fnName + '(' + fnArgs + ')'));
         });
 
         // generate file to string

--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -39,7 +39,12 @@ module.exports = function(grunt) {
           var fnArgs = e.map(function (arg) {
             return JSON.stringify(arg);
           }).join(', ');
-          css.use(eval(fnName + '(' + fnArgs + ')'));
+          if (typeof fnName === 'function') {
+            css.use(fnName(fnArgs));
+          }
+          else {
+            css.use(eval(fnName + '(' + fnArgs + ')'));
+          }
         });
 
         // generate file to string


### PR DESCRIPTION
Example:

```
var queryless = require('queryless');

module.exports = function(grunt) {
  grunt.initConfig({
    rework: {
      target: { files: { 'out.css', 'in.css' } },
      options: {
        use: [
          [queryless, 'screen and (min-width: 60em)']
        ]
      }
    }
  })
};
```
