### PR TITLE
Upgrade rework to 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "./node_modules/grunt-cli/bin/grunt test"
   },
   "dependencies": {
-    "rework": "0.13.2"
+    "rework": "0.18.1"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
**This is a breaking change**

I don’t know what’s changed well enough in how rework works internally or how the nested array eval loop was meant to work. I just ran the tests and they fail with this change. If you have any thoughts or pointers I can look into it.
