### PR TITLE
applying arguments when using a function reference

### DIFF
--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -36,15 +36,15 @@ module.exports = function(grunt) {
         options.use.forEach(function (e) {
           e = e.slice();
           var fnName = e.shift();
-          
+
           if (typeof fnName === 'function') {
-            return css.use(fnName(e));
+            return css.use(fnName.apply(fnName, e));
           }
-          
+
           var fnArgs = e.map(function (arg) {
             return JSON.stringify(arg);
           }).join(', ');
-          
+
           css.use(eval(fnName + '(' + fnArgs + ')'));
         });
 


### PR DESCRIPTION
Wrote my Gruntfile as below because using `rework-vars` didn't work, nor did `rework.vars`. This seemed easiest.
Then the plugins failed because an empty array was being sent as the first argument. 

`fnName.apply(fnName, e)` worked great.

``` javascript
var reworkVars = require('rework-vars')
var reworkImporter = require('rework-importer')

module.exports = function(grunt) {
  grunt.initConfig({
    rework: {
      'public/css/styles.css': __dirname+'/css/styles.css',
      options: {
        use: [
          [reworkImporter],
          [reworkVars]
        ]
      }
    }
  })
}
```
