### PR TITLE
Pass custom plugins to use

### DIFF
--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -34,6 +34,11 @@ module.exports = function(grunt) {
         var css = rework(srcCode).vendors(options.vendors);
 
         options.use.forEach(function (e) {
+
+          // If a function was passed, then just use that
+          if (typeof e === 'function')
+            return css.use(e)
+
           e = e.slice();
           var fnName = e.shift();
 

--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -36,8 +36,9 @@ module.exports = function(grunt) {
         options.use.forEach(function (e) {
 
           // If a function was passed, then just use that
-          if (typeof e === 'function')
-            return css.use(e)
+          if (typeof e === 'function'){
+            return css.use(e);
+          }
 
           e = e.slice();
           var fnName = e.shift();


### PR DESCRIPTION
Hi there, 

I've got a custom rework plugin that I require() in my Gruntfile, and couldn't figure out how to pass it properly to grunt-rework. This patch allows you to just configure the plugin in the Gruntfile and pass it directly to Rework like so:

```
var reworkNamespace = require('rework-namespace-css')

...

use: [
    reworkNamespace({
        selector: '.wfa',
    })
],

```

If this functionality already exists then feel free to ignore, and maybe let me know the preferred method.

Thanks
