### PR TITLE
Write source map into its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ Default: `{}`
 
 Options to pass to rework's `toString` method.
 
+If `toString.sourcemapAsObject` is set to `true`, you can use these additional options:
+
+#### toString.sourceMapFilename
+Type: `String`
+
+Default: none
+
+Write the source map to a separate file with the given filename. If not specified the destination file path will be used with a `.map` suffix.
+
+#### toString.sourceMapURL
+Type: `String`
+
+Default: none
+
+Override the default url that points to the sourcemap from the compiled css file.
+
+#### toString.sourceMapRootpath
+Type: `String`
+
+Default: none
+
+Adds this path onto the less file paths in the source map.
+
 
 ## Release History
 

--- a/tasks/grunt-rework.js
+++ b/tasks/grunt-rework.js
@@ -42,9 +42,37 @@ module.exports = function(grunt) {
 
         var dest = _.isFunction(options.processName) ? options.processName(srcFile, res) : file.dest;
 
-        grunt.file.write(dest, res);
+        // if sourcemapAsObject is true, write source map into its own file
+        if(options.toString && options.toString.sourcemapAsObject) {
+          // if sourceMapFilename isn't set use dest with '.map' suffix
+          var mapDest = options.toString.sourceMapFilename || dest + '.map';
 
-        grunt.log.writeln('File "' + dest + '" created.');
+          // if sourceMapURL isn't set use sourceMapFilename
+          var sourceMapURL = options.toString.sourceMapURL || options.toString.sourceMapFilename;
+          res.code = res.code + '\n/*# sourceMappingURL=' + sourceMapURL + ' */';
+
+          // if sourceMapRootpath is set, use it as prefix for res.map.sources
+          if(options.toString.sourceMapRootpath) {
+            var sourceMapRootpath = options.toString.sourceMapRootpath;
+            // append '/' if necessary
+            if(sourceMapRootpath.charAt(sourceMapRootpath.length - 1) !== '/') {
+              sourceMapRootpath += '/';
+            }
+            res.map.sources.forEach(function(source, i) {
+              res.map.sources[i] = sourceMapRootpath + source;
+            });
+          }
+
+          grunt.file.write(dest, res.code);
+          grunt.file.write(mapDest, JSON.stringify(res.map));
+
+          grunt.log.writeln('File "' + dest + '" created.');
+          grunt.log.writeln('File "' + mapDest + '" created.');
+        } else {
+          grunt.file.write(dest, res);
+
+          grunt.log.writeln('File "' + dest + '" created.');
+        }
 
         nextFile();
       }, next);


### PR DESCRIPTION
If `toString.sourcemapAsObject` is set to `true` the resulting CSS was garbage before, as it only contained `[object Object]`. 

Now it writes the source map into its own file using some (optional) settings taken from https://github.com/gruntjs/grunt-contrib-less/blob/master/README.md#sourcemap.
These are: `sourceMapFilename`, `sourceMapURL` and `sourceMapRootpath`.

This could be seen as a _future polyfill_ as I hope this will be a core feature soon. See https://github.com/reworkcss/rework/issues/176.
